### PR TITLE
Use cmake instead of zlib's configure

### DIFF
--- a/patches/ports/zlib/1.2.8/package.sh
+++ b/patches/ports/zlib/1.2.8/package.sh
@@ -1,14 +1,14 @@
 REMOTE_ARCHIVE="https://ghostkernel.org/repository/zlib/zlib-1.2.8.tar.gz"
 UNPACKED_DIR=zlib-1.2.8
 ARCHIVE=zlib-1.2.8.tar.gz
-REQUIRES_INSTALL_IN_SOURCE_DIR=1
+REQUIRES_INSTALL_IN_SOURCE_DIR=0
 
 port_unpack() {
 	tar -xf $ARCHIVE
 }
 
 port_install() {
-	CHOST=i686-ghost CC=$HOST-gcc ./configure --static --prefix=$PREFIX
+	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../../../../../../i686-ghost-toolchain.cmake ../$UNPACKED_DIR
 	make
 	make DESTDIR=$SYSROOT install
 }


### PR DESCRIPTION
A very simple change. This has two advantages:

- cmake will complain giving a proper error message if the toolchain is not installed beforehand
- allows out of source build